### PR TITLE
Notify via email

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,26 @@
 Console application that scrapes www.slickdeals.net and notifies when there are any deals with more than 100 votes.
 
 Uses SQLite to make sure it doesn't notify duplicate deals.
+
+## Email notification setup
+
+If you want to run the notifier and enable email notifications when a deal meets your notification criteria, you must create a [SendGrid](https://www.twilio.com/sendgrid/email-api) account and follow the instructions to generate an API Key and Single Sender Verification.
+
+### Setting up your Sendgrid API Key
+
+To set up your SendGrid API Key, follow the [Email Web API](https://app.sendgrid.com/guide/integrate) steps in the SendGrid app, then create an environment variable called `SLICKDEALS_SENDGRID_APIKEY` and set its value to the API Key generated there.
+
+### Setting the "mail from" and "email to" addresses
+
+Go through the [Single Sender Verification](https://app.sendgrid.com/settings/sender_auth/senders/new) steps in the SendGrid app, then update appsettings.config with the email address you used for the verification.
+
+```json
+{
+  "EmailFrom": "single-sender-email@mail.com",
+  "EmailTo": "any-email-you-want@mail.com"
+}
+```
+
+## Contributions
+
+PRs are welcome! If you see any area of improvement, feel free to create a PR to address it.

--- a/src/SlickDealsNotifier/ApplicationConfiguration.cs
+++ b/src/SlickDealsNotifier/ApplicationConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace SlickdealsNotifier
+{
+    public class ApplicationConfiguration
+    {
+        public string EmailFrom { get; set; }
+
+        public string EmailTo { get; set; }
+    }
+}

--- a/src/SlickDealsNotifier/Business/ISlickDealsNotifierBusiness.cs
+++ b/src/SlickDealsNotifier/Business/ISlickDealsNotifierBusiness.cs
@@ -4,6 +4,6 @@ namespace SlickdealsNotifier.Business
 {
     public interface ISlickDealsNotifierBusiness
     {
-        Task NotifyNewDeals();
+        Task NotifyNewDeals(ApplicationConfiguration applicationConfiguration);
     }
 }

--- a/src/SlickDealsNotifier/Models/Deal.cs
+++ b/src/SlickDealsNotifier/Models/Deal.cs
@@ -30,5 +30,11 @@ namespace SlickdealsNotifier.Models
         public int Votes { get; set; }
         public bool IsFire { get; set; }
         public string Url { get; set; }
+
+        // auto generated via https://marketplace.visualstudio.com/items?itemName=DavideLettieri.AutoToString
+        public override string ToString()
+        {
+            return $"{{{nameof(Title)}={Title}, {nameof(Store)}={Store}, {nameof(Price)}={Price}, {nameof(Votes)}={Votes.ToString()}, {nameof(IsFire)}={IsFire.ToString()}, {nameof(Url)}={Url}}}";
+        }
     }
 }

--- a/src/SlickDealsNotifier/Notification/IDealNotifier.cs
+++ b/src/SlickDealsNotifier/Notification/IDealNotifier.cs
@@ -1,0 +1,10 @@
+﻿using SlickdealsNotifier.Models;
+using System.Threading.Tasks;
+
+namespace SlickdealsNotifier.Notification
+{
+    public interface IDealNotifier
+    {
+        Task<bool> Notify(Deal deal, ApplicationConfiguration applicationConfiguration);
+    }
+}

--- a/src/SlickDealsNotifier/Notification/SendGridEmailNotifier.cs
+++ b/src/SlickDealsNotifier/Notification/SendGridEmailNotifier.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Extensions.Logging;
+using SendGrid;
+using SendGrid.Helpers.Mail;
+using SlickdealsNotifier.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace SlickdealsNotifier.Notification
+{
+    public class SendGridEmailNotifier : IDealNotifier
+    {
+        private readonly ILogger<SendGridEmailNotifier> _logger;
+
+        public SendGridEmailNotifier(ILogger<SendGridEmailNotifier> logger)
+        {
+            _logger = logger;
+        }
+
+
+        public async Task<bool> Notify(Deal deal, ApplicationConfiguration applicationConfiguration)
+        {
+            var apiKey = Environment.GetEnvironmentVariable("SLICKDEALS_SENDGRID_APIKEY");
+            var client = new SendGridClient(apiKey);
+            var from = new EmailAddress(applicationConfiguration.EmailFrom, "Slickdeals Notifier");
+            var subject = $"New Slick Deal: {deal.Title}, price: {deal.Price}, at {deal.Store}";
+            var to = new EmailAddress(applicationConfiguration.EmailTo, "Slickdeals Recipient");
+            var plainTextContent = $"A new Slick Deal is Available: {Environment.NewLine}{deal}";
+            var htmlContent = $"<a href=\"{ deal.Url}\">Link to SlickDeals</a>";
+            var msg = MailHelper.CreateSingleEmail(from, to, subject, plainTextContent, htmlContent);
+            try
+            {
+                _logger.LogDebug($"Sending deal email with content {msg.PlainTextContent}");
+
+                var response = await client.SendEmailAsync(msg);
+
+                _logger.LogDebug($"Email send attempted. Response Status Code: {response.StatusCode}");
+                return response.IsSuccessStatusCode;
+
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError($"Failed to send email. Exception: {ex.Message}");
+                return false;
+            }
+        }
+    }
+}

--- a/src/SlickDealsNotifier/Program.cs
+++ b/src/SlickDealsNotifier/Program.cs
@@ -1,10 +1,13 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SlickdealsNotifier.Business;
 using SlickdealsNotifier.Data;
+using SlickdealsNotifier.Notification;
 using SlickdealsNotifier.Scraping;
 
 namespace SlickdealsNotifier
@@ -13,12 +16,22 @@ namespace SlickdealsNotifier
     {
         public static async Task Main(string[] args)
         {
+            var configurationRoot = new ConfigurationBuilder()
+                .SetBasePath(Directory.GetParent(AppContext.BaseDirectory).FullName)
+                .AddJsonFile("appsettings.json", false)
+                .Build();
+
+            var appConfiguration = configurationRoot.Get<ApplicationConfiguration>();
+
             var serviceProvider = new ServiceCollection()
                 .AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Debug))
                 .AddSingleton<ISlickDealsNotifierBusiness, SlickDealsNotifierBusiness>()
                 .AddSingleton<IHtmlContentLoader, HtmlContentLoader>()
                 .AddSingleton<IHtmlContentParser, HtmlContentParser>()
                 .AddSingleton<IDealDataAccess, DealDataAccess>()
+                // maybe in the future if more types of notifications are added
+                // use factory to decide which implementation to register in DI
+                .AddSingleton<IDealNotifier, SendGridEmailNotifier>()
                 .BuildServiceProvider();
 
             var logger = serviceProvider.GetService<ILoggerFactory>()
@@ -27,7 +40,7 @@ namespace SlickdealsNotifier
             logger.LogDebug("Starting application");
 
             var business = serviceProvider.GetService<ISlickDealsNotifierBusiness>();
-            await business.NotifyNewDeals();
+            await business.NotifyNewDeals(appConfiguration);
 
             logger.LogDebug("Completed scraping and notifying");
         }

--- a/src/SlickDealsNotifier/SlickdealsNotifier.csproj
+++ b/src/SlickDealsNotifier/SlickdealsNotifier.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -17,11 +17,23 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="3.1.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.8" />
+    <PackageReference Include="SendGrid" Version="9.24.3" />
     <PackageReference Include="Serilog" Version="2.9.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/src/SlickDealsNotifier/appsettings.json
+++ b/src/SlickDealsNotifier/appsettings.json
@@ -1,0 +1,4 @@
+{
+    "EmailFrom": "email.from@mail.com",
+    "EmailTo": "email.to@mail.com"
+}


### PR DESCRIPTION
Added a way to notify via email.

Uses Twilio SendGrid, single sender verification seems to not work for Gmail, Outlook or ProtonMail, even though API calls are returning success status, the mails aren't being sent, but pretty sure setting up a paid email account should work. May look into alternatives to Twilio, I remember MailGun didn't require that much setup a long time ago.